### PR TITLE
refactor: improve PlayerAPI usage in the player listener

### DIFF
--- a/velocity-plugin/src/main/java/net/onelitefeather/otis/velocity/OtisPlugin.java
+++ b/velocity-plugin/src/main/java/net/onelitefeather/otis/velocity/OtisPlugin.java
@@ -42,7 +42,7 @@ public class OtisPlugin {
         this.logger.info("Initialized Otis client");
         
         // Register event listeners
-        this.server.getEventManager().register(this, new PlayerListener(this));
+        this.server.getEventManager().register(this, new PlayerListener(this.logger, this.client));
         this.logger.info("Registered event listeners");
         
         this.logger.info("Otis plugin initialized successfully");

--- a/velocity-plugin/src/main/java/net/onelitefeather/otis/velocity/listener/PlayerListener.java
+++ b/velocity-plugin/src/main/java/net/onelitefeather/otis/velocity/listener/PlayerListener.java
@@ -9,7 +9,6 @@ import net.onelitefeather.otis.client.invoker.ApiClient;
 import net.onelitefeather.otis.client.invoker.ApiException;
 import net.onelitefeather.otis.client.model.AddPlayerRequest;
 import net.onelitefeather.otis.client.model.OtisPlayerDTO;
-import net.onelitefeather.otis.velocity.OtisPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
@@ -21,17 +20,18 @@ import java.util.UUID;
  */
 public class PlayerListener {
 
-    private final OtisPlugin plugin;
+    private final PlayerApi playerApi;
     private final Logger logger;
 
     /**
      * Creates a new player listener.
      *
-     * @param plugin the plugin instance
+     * @param logger    the logger
+     * @param apiClient the API client
      */
-    public PlayerListener(@NotNull OtisPlugin plugin) {
-        this.plugin = plugin;
-        this.logger = plugin.getLogger();
+    public PlayerListener(@NotNull Logger logger, @NotNull ApiClient apiClient) {
+        this.playerApi = new PlayerApi(apiClient);
+        this.logger = logger;
     }
 
     /**
@@ -45,10 +45,8 @@ public class PlayerListener {
         UUID uuid = player.getUniqueId();
         String playerName = player.getUsername();
         long currentTime = System.currentTimeMillis();
-        ApiClient client = this.plugin.getClient();
-        PlayerApi apiInstance = new PlayerApi(client);
         try {
-            OtisPlayerDTO id = apiInstance.getPlayerById(uuid);
+            OtisPlayerDTO id = this.playerApi.getPlayerById(uuid);
             updatePlayer(uuid, playerName, id, currentTime);
         } catch (ApiException e) {
             if (e.getCode() == 404) {
@@ -73,10 +71,8 @@ public class PlayerListener {
         UUID uuid = player.getUniqueId();
         String playerName = player.getUsername();
         long currentTime = System.currentTimeMillis();
-        ApiClient client = this.plugin.getClient();
-        PlayerApi apiInstance = new PlayerApi(client);
         try {
-            OtisPlayerDTO existingPlayer = apiInstance.getPlayerById(uuid);
+            OtisPlayerDTO existingPlayer = this.playerApi.getPlayerById(uuid);
             updatePlayer(uuid, playerName, existingPlayer, currentTime);
         } catch (ApiException e) {
             if (e.getCode() == 404) {
@@ -90,8 +86,8 @@ public class PlayerListener {
     /**
      * Creates a new player.
      *
-     * @param uuid       the player UUID
-     * @param playerName the player name
+     * @param uuid        the player UUID
+     * @param playerName  the player name
      * @param currentTime the current time
      */
     private void createPlayer(@NotNull UUID uuid, @NotNull String playerName, long currentTime) {
@@ -101,11 +97,8 @@ public class PlayerListener {
                 .playerUuid(uuid)
                 .profileTextures(new HashMap<>())
                 .build();
-
-        ApiClient client = this.plugin.getClient();
-        PlayerApi apiInstance = new PlayerApi(client);
         try {
-            apiInstance.addPlayer(AddPlayerRequest.builder()
+            this.playerApi.addPlayer(AddPlayerRequest.builder()
                     .playerDTO(newPlayer).build());
         } catch (ApiException e) {
             if (e.getCode() == 500) {
@@ -121,22 +114,20 @@ public class PlayerListener {
     /**
      * Updates an existing player.
      *
-     * @param uuid         the player UUID
-     * @param playerName   the player name
+     * @param uuid           the player UUID
+     * @param playerName     the player name
      * @param existingPlayer the existing player data
-     * @param currentTime  the current time
+     * @param currentTime    the current time
      */
-    private void updatePlayer(@NotNull UUID uuid, @NotNull String playerName, 
-                             @NotNull OtisPlayerDTO existingPlayer, long currentTime) {
+    private void updatePlayer(@NotNull UUID uuid, @NotNull String playerName,
+                              @NotNull OtisPlayerDTO existingPlayer, long currentTime) {
         // Create updated player with new last join time
         OtisPlayerDTO updatedPlayer = existingPlayer.toBuilder()
                 .lastJoin(currentTime)
                 .playerName(playerName)
                 .build();
-        ApiClient client = this.plugin.getClient();
-        PlayerApi apiInstance = new PlayerApi(client);
         try {
-            apiInstance.updatePlayer(uuid, AddPlayerRequest.builder()
+            this.playerApi.updatePlayer(uuid, AddPlayerRequest.builder()
                     .playerDTO(updatedPlayer).build());
         } catch (ApiException e) {
             if (e.getCode() == 400) {


### PR DESCRIPTION
## Proposed changes

The `PlayerApi` from the generated Java client is stateless and only requires an `ApiClient` reference. To avoid unnecessary object creation, the player listener has been refactored to use a single shared instance of `PlayerApi`.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)