### PR TITLE
ci: Maven/java release-please flow + split Gradle from Docker publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,30 +32,46 @@ jobs:
   publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.2.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.3.0
     with:
       java-version: "25.0.3"
       java-distribution: "temurin"
     secrets: inherit
 
-  docker:
-    name: Build Docker Artifacts
+  # Gradle produces the Micronaut optimized Docker context and uploads it as an
+  # artifact for the (toolchain-agnostic) docker-publish job to consume.
+  build-context:
+    name: Build Docker context
     needs: release-please
-    permissions:
-      contents: read
-      id-token: write   # keyless cosign signing via GitHub OIDC
     # Runs on a real release, or on a manual dispatch to (re)publish a given version.
     if: |
       always() &&
       ((github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
        github.event_name == 'workflow_dispatch')
-    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.2.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-docker-context.yml@v2.3.0
+    with:
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_version || needs.release-please.outputs.version }}
+      gradle-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
+      context-path: "backend/build/docker/optimized"
+      artifact-name: "docker-context-release"
+    secrets: inherit
+
+  docker:
+    name: Build Docker Artifacts
+    needs: [release-please, build-context]
+    permissions:
+      contents: read
+      id-token: write   # keyless cosign signing via GitHub OIDC
+    if: |
+      always() && needs.build-context.result == 'success' &&
+      ((github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
+       github.event_name == 'workflow_dispatch')
+    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.3.0
     with:
       image-name: "onelitefeather/otis"
       version: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_version || needs.release-please.outputs.version }}
-      setup-java: true
-      build-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
-      context: "./backend/build/docker/optimized"
+      context: "backend/build/docker/optimized"
+      artifact-name: "docker-context-release"
       blob-chunk: "90000000"   # ~90 MB, under the 100 MB Cloudflare cap
       req-concurrent: "4"
     secrets: inherit


### PR DESCRIPTION
Brings Otis in line with Vulpes-Backend's release pipeline.

## 1. Pure Docker build (split Gradle from docker-publish)

`docker-publish.yml` becomes toolchain-agnostic (OneLiteFeatherNET/workflows#15). The Gradle step that generates the Micronaut optimized context moves into the new reusable `gradle-docker-context.yml` producer, which uploads the context as an artifact for `docker-publish` to consume.

- `publish` and Docker jobs bump to `@v2.3.0`.
- New `build-context` job runs `./gradlew jar optimizedBuildLayers optimizedDockerfile` and uploads `backend/build/docker/optimized` as an artifact.
- `docker` drops `setup-java`/`build-command`; consumes the artifact via `artifact-name`.

## 2. Maven (java) release-please flow + snapshots

Switch the package to `release-type: java` so release-please manages the Maven SNAPSHOT lifecycle (release → bump to next `-SNAPSHOT`), with `gradle.properties` updated via the generic updater — exactly like Vulpes-Backend.

Add the snapshot CI that flow implies:
- `version` job reads `gradle.properties` on non-release pushes.
- `publish-snapshot` publishes to the snapshot Maven repo (`java-client` / `velocity-plugin` already route SNAPSHOT/BETA/ALPHA there).
- `build-context-snapshot` + `docker-snapshot` build & push a snapshot image on every non-release push.

After merge, expect release-please to open a `…-SNAPSHOT` bump PR (same dance Vulpes went through). `gradle.properties` is intentionally left at `1.14.0` — release-please drives it from here.

## ⚠️ Merge order

Depends on **OneLiteFeatherNET/workflows#15** merged + released as **`v2.3.0`** first (the `@v2.3.0` refs won't resolve until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)