### PR TITLE
feat: enable /health and /prometheus management endpoints

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,6 +4,13 @@ micronaut:
       parser-features:
   application:
     name: Otis API
+  metrics:
+    enabled: true
+    export:
+      prometheus:
+        enabled: true
+        step: PT1M
+        descriptions: true
 
 # Datasource
 datasources:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -51,6 +51,17 @@ otel:
     - /swagger/.*
     - /swagger-ui/.*
 
+# Management endpoints — /health for liveness/readiness probes,
+# /prometheus for metrics scraping (both non-sensitive for internal scraping).
+endpoints:
+  health:
+    enabled: true
+    sensitive: false
+    details-visible: ANONYMOUS
+  prometheus:
+    enabled: true
+    sensitive: false
+
 # OpenAPI
 router:
   static-resources:


### PR DESCRIPTION
## Why

Expose Micronaut management endpoints so Prometheus can scrape metrics and orchestrators can run liveness/readiness probes. Complements the observability stack (logs → Loki, traces → Tempo, metrics → Prometheus). Mirrors the setup added to the Vulpes backend.

## What

- **Metrics** (`micronaut.metrics`): enable the Micrometer Prometheus registry export (`step: PT1M`, descriptions on).
- **Endpoints** (`endpoints`): expose `/health` (details visible) and `/prometheus`, both `sensitive: false` for internal scraping.

`micronaut-management` was already a dependency, so this is config-only.

## Endpoints

- `GET /health` — liveness/readiness
- `GET /prometheus` — metrics scrape target

## Verification

- `./gradlew :backend:compileJava` ✅
- Config-only change; no dependency or build changes.