### PR TITLE
feat: enable Kubernetes service discovery client

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
     implementation(mn.micronaut.management)
     implementation(mn.micronaut.micrometer.core)
     implementation(mn.micronaut.micrometer.registry.prometheus)
+    // Kubernetes service discovery — beans only activate in the k8s environment,
+    // so this is inert in local/dev. Needs RBAC (read services/endpoints) in-cluster.
+    implementation(mn.micronaut.kubernetes.discovery.client)
     implementation(mn.micronaut.http.client.jdk)
     implementation(mn.micronaut.openapi)
     implementation(mn.swagger.core)


### PR DESCRIPTION
## Why

In-cluster, `/health` showed `compositeDiscoveryClient` with an empty `services: {}` — no discovery backend was configured. This adds Micronaut's Kubernetes discovery client so the app discovers services in its **own namespace**.

## What

- Add `micronaut-kubernetes-discovery-client` (micronaut-kubernetes 7.1.1).

The module's beans only activate in the Kubernetes environment, so it is inert for local/dev runs. In-cluster it additionally requires:
- RBAC: `get/list/watch` on `services` and `endpoints` (added in the Helm chart `helm/micronaut`).
- The `k8s` environment active (set via the deployment's profiles).

See the companion Kubernetes-FLUX change for the RBAC + release wiring.

## Verification

- `./gradlew :backend:compileJava` ✅
- Resolves: `micronaut-kubernetes-discovery-client:7.1.1`, `micronaut-discovery-client:4.7.1`.